### PR TITLE
Fix api link

### DIFF
--- a/pages/getting-started.mdx
+++ b/pages/getting-started.mdx
@@ -252,4 +252,4 @@ export default Home;
 
 ## With JavaScript
 
-**Do you use some other framework? Or no framework at all?** You can directly use `styletron-engine-atomic` to render styles. Check the [API documentation](/api).
+**Do you use some other framework? Or no framework at all?** You can directly use `styletron-engine-atomic` to render styles. Check the [API documentation](/api-reference).


### PR DESCRIPTION
Currently this links to `/api` which is used for Next.js API Routes. The correct link should be `api-reference`.